### PR TITLE
Add Toggles to settings page

### DIFF
--- a/src/components/settings/SettingsSidebar.tsx
+++ b/src/components/settings/SettingsSidebar.tsx
@@ -51,6 +51,9 @@ export function SettingsSidebar() {
           <SettingsLink to="/settings/trackers" scrollTo="mechanics">
             Tracker mechanics
           </SettingsLink>
+          <SettingsLink to="/settings/trackers" scrollTo="fksettings">
+            FK settings
+          </SettingsLink>
           <SettingsLink to="/settings/trackers" scrollTo="interface">
             Interface
           </SettingsLink>

--- a/src/components/settings/pages/GeneralSettings.tsx
+++ b/src/components/settings/pages/GeneralSettings.tsx
@@ -277,10 +277,10 @@ export function GeneralSettings() {
           <Typography bold>Leg-tweaks</Typography>
           <div className="flex flex-col pt-2 pb-4">
             <Typography color="secondary">
-              Floor-clip can Reduces or even eliminates clipping with the floor
+              Floor-clip can Reduce or even eliminates clipping with the floor
               but may cause problems when on your knees. Skating-correction
               corrects for ice skating, but can decrease accuracy in certain
-              movment patterns.
+              movement patterns.
             </Typography>
           </div>
           <div className="grid grid-cols-2 gap-3 pb-5">
@@ -303,10 +303,10 @@ export function GeneralSettings() {
           <Typography bold>Arm-FK</Typography>
           <div className="flex flex-col pt-2 pb-4">
             <Typography color="secondary">
-              Settings for how the arm kinematics behave.
+              Change the way the arm is tracked.
             </Typography>
           </div>
-          <div className="grid grid-cols-1 pb-5">
+          <div className="grid grid-cols-2 pb-5">
             <CheckBox
               variant="toggle"
               outlined
@@ -319,11 +319,11 @@ export function GeneralSettings() {
             <Typography bold>Skeleton settings</Typography>
             <div className="flex flex-col pt-2 pb-4">
               <Typography color="secondary">
-                More settings that allow further tweaking of the fk settings. It
-                it is recomended to leave these at the default.
+                More settings that allow further tweaking of the FK settings. It
+                is recommended to leave these on.
               </Typography>
             </div>
-            <div className="grid grid-cols-3 gap-3 pb-5">
+            <div className="grid grid-cols-2 gap-3 pb-5">
               <CheckBox
                 variant="toggle"
                 outlined

--- a/src/components/settings/pages/GeneralSettings.tsx
+++ b/src/components/settings/pages/GeneralSettings.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react';
-import { useForm } from 'react-hook-form';
+import { DefaultValues, useForm, UseFormReset } from 'react-hook-form';
 import { useLocation } from 'react-router-dom';
 import {
   ChangeSettingsRequestT,
@@ -37,12 +37,12 @@ interface SettingsForm {
     amount: number;
   };
   toggles: {
-    extendedSpine: boolean | null;
-    extendedPelvis: boolean | null;
-    extendedKnee: boolean | null;
-    forceArmsFromHmd: boolean | null;
-    floorClip: boolean | null;
-    skatingCorrection: boolean | null;
+    extendedSpine: boolean;
+    extendedPelvis: boolean;
+    extendedKnee: boolean;
+    forceArmsFromHmd: boolean;
+    floorClip: boolean;
+    skatingCorrection: boolean;
   };
   interface: {
     devmode: boolean;
@@ -131,18 +131,35 @@ export function GeneralSettings() {
   }, []);
 
   useRPCPacket(RpcMessage.SettingsResponse, (settings: SettingsResponseT) => {
-    reset({
-      ...(settings.steamVrTrackers
-        ? { trackers: settings.steamVrTrackers }
-        : {}),
-      ...(settings.modelSettings?.toggles
-        ? { toggles: settings.modelSettings?.toggles }
-        : {}),
-      ...(settings.filtering ? { filtering: settings.filtering } : {}),
+    const formData: DefaultValues<SettingsForm> = {
       interface: {
         devmode: config?.debug,
       },
-    });
+    };
+
+    if (settings.filtering) {
+      formData.filtering = settings.filtering;
+    }
+
+    if (settings.steamVrTrackers) {
+      formData.trackers = settings.steamVrTrackers;
+    }
+
+    if (settings.modelSettings?.toggles) {
+      formData.toggles = Object.keys(settings.modelSettings?.toggles).reduce(
+        (curr, key: string) => ({
+          ...curr,
+          [key]:
+            (settings.modelSettings?.toggles &&
+              (settings.modelSettings.toggles as any)[key]) ||
+            false,
+        }),
+        {}
+      );
+      console.log(formData.toggles);
+    }
+
+    reset(formData);
   });
 
   // Handle scrolling to selected page

--- a/src/components/settings/pages/GeneralSettings.tsx
+++ b/src/components/settings/pages/GeneralSettings.tsx
@@ -156,7 +156,6 @@ export function GeneralSettings() {
         }),
         {}
       );
-      console.log(formData.toggles);
     }
 
     reset(formData);

--- a/src/components/settings/pages/GeneralSettings.tsx
+++ b/src/components/settings/pages/GeneralSettings.tsx
@@ -274,7 +274,7 @@ export function GeneralSettings() {
       <SettingsPageLayout icon={<WrenchIcon></WrenchIcon>} id="fksettings">
         <>
           <Typography variant="main-title">FK settings</Typography>
-          <Typography bold>Leg-tweaks</Typography>
+          <Typography bold>Leg tweaks</Typography>
           <div className="flex flex-col pt-2 pb-4">
             <Typography color="secondary">
               Floor-clip can Reduce or even eliminates clipping with the floor
@@ -300,10 +300,10 @@ export function GeneralSettings() {
             />
           </div>
 
-          <Typography bold>Arm-FK</Typography>
+          <Typography bold>Arm FK</Typography>
           <div className="flex flex-col pt-2 pb-4">
             <Typography color="secondary">
-              Change the way the arm is tracked.
+              Change the way the arms are tracked.
             </Typography>
           </div>
           <div className="grid grid-cols-2 pb-5">
@@ -319,8 +319,8 @@ export function GeneralSettings() {
             <Typography bold>Skeleton settings</Typography>
             <div className="flex flex-col pt-2 pb-4">
               <Typography color="secondary">
-                More settings that allow further tweaking of the FK settings. It
-                is recommended to leave these on.
+                Toggle skeleton settings on or off. It is recommended to leave
+                these on.
               </Typography>
             </div>
             <div className="grid grid-cols-2 gap-3 pb-5">
@@ -329,21 +329,21 @@ export function GeneralSettings() {
                 outlined
                 control={control}
                 name="toggles.extendedSpine"
-                label="Extended Spine"
+                label="Extended spine"
               />
               <CheckBox
                 variant="toggle"
                 outlined
                 control={control}
                 name="toggles.extendedPelvis"
-                label="Extended Pelvis"
+                label="Extended pelvis"
               />
               <CheckBox
                 variant="toggle"
                 outlined
                 control={control}
                 name="toggles.extendedKnee"
-                label="Extended Knee"
+                label="Extended knee"
               />
             </div>
           </div>

--- a/src/components/settings/pages/GeneralSettings.tsx
+++ b/src/components/settings/pages/GeneralSettings.tsx
@@ -7,6 +7,7 @@ import {
   FilteringType,
   ModelSettingsT,
   ModelTogglesT,
+  ModelRatiosT,
   RpcMessage,
   SettingsRequestT,
   SettingsResponseT,
@@ -37,12 +38,12 @@ interface SettingsForm {
     ticks: number;
   };
   toggles: {
-    extendedSpine: boolean;
-    extendedPelvis: boolean;
-    extendedKnee: boolean;
-    forceArmsFromHmd: boolean;
-    floorClip: boolean;
-    skatingCorrection: boolean;
+    extendedSpine: boolean | null;
+    extendedPelvis: boolean | null;
+    extendedKnee: boolean | null;
+    forceArmsFromHmd: boolean | null;
+    floorClip: boolean | null;
+    skatingCorrection: boolean | null;
   };
   interface: {
     devmode: boolean;
@@ -70,7 +71,7 @@ export function GeneralSettings() {
           extendedPelvis: true,
           extendedKnee: true,
           forceArmsFromHmd: false,
-          floorClip: true,
+          floorClip: false,
           skatingCorrection: false,
         },
         filtering: { intensity: 0, ticks: 0 },
@@ -128,8 +129,8 @@ export function GeneralSettings() {
       ...(settings.steamVrTrackers
         ? { trackers: settings.steamVrTrackers }
         : {}),
-      ...(settings.modelSettings.toggles
-        ? { toggles: settings.modelSettings.toggles }
+      ...(settings.modelSettings?.toggles
+        ? { toggles: settings.modelSettings?.toggles }
         : {}),
       ...(settings.filtering ? { filtering: settings.filtering } : {}),
       interface: {

--- a/src/components/settings/pages/GeneralSettings.tsx
+++ b/src/components/settings/pages/GeneralSettings.tsx
@@ -265,10 +265,10 @@ export function GeneralSettings() {
             <div className="flex flex-col pt-2 pb-4">
               <Typography bold>Secondary Filtering</Typography>
               <Typography color="secondary">
-                Floor clip can Reduces or even eliminates clipping with the but
-                but may cause problems when on your knees. Skating correction
-                corrects for ice skating, but can decrease accuracy in certain
-                movment patterns.
+                Floor-clip can Reduces or even eliminates clipping with the
+                floor but may cause problems when on your knees.
+                Skating-correction corrects for ice skating, but can decrease
+                accuracy in certain movment patterns.
               </Typography>
             </div>
             <div className="grid grid-cols-2 gap-3 pt-3 ">

--- a/src/components/settings/pages/GeneralSettings.tsx
+++ b/src/components/settings/pages/GeneralSettings.tsx
@@ -261,35 +261,39 @@ export function GeneralSettings() {
               step={1}
             />
           </div>
+        </>
+      </SettingsPageLayout>
+      <SettingsPageLayout icon={<WrenchIcon></WrenchIcon>} id="fksettings">
+        <>
+          <Typography variant="main-title">FK settings</Typography>
+          <Typography bold>Leg-tweaks</Typography>
           <div className="flex flex-col pt-2 pb-4">
-            <div className="flex flex-col pt-2 pb-4">
-              <Typography bold>Secondary Filtering</Typography>
-              <Typography color="secondary">
-                Floor-clip can Reduces or even eliminates clipping with the
-                floor but may cause problems when on your knees.
-                Skating-correction corrects for ice skating, but can decrease
-                accuracy in certain movment patterns.
-              </Typography>
-            </div>
-            <div className="grid grid-cols-2 gap-3 pt-3 ">
-              <CheckBox
-                variant="toggle"
-                outlined
-                control={control}
-                name="toggles.floorClip"
-                label="Floor clip"
-              />
-              <CheckBox
-                variant="toggle"
-                outlined
-                control={control}
-                name="toggles.skatingCorrection"
-                label="Skating correction"
-              />
-            </div>
+            <Typography color="secondary">
+              Floor-clip can Reduces or even eliminates clipping with the floor
+              but may cause problems when on your knees. Skating-correction
+              corrects for ice skating, but can decrease accuracy in certain
+              movment patterns.
+            </Typography>
+          </div>
+          <div className="grid grid-cols-2 gap-3 pt-3 ">
+            <CheckBox
+              variant="toggle"
+              outlined
+              control={control}
+              name="toggles.floorClip"
+              label="Floor clip"
+            />
+            <CheckBox
+              variant="toggle"
+              outlined
+              control={control}
+              name="toggles.skatingCorrection"
+              label="Skating correction"
+            />
           </div>
         </>
       </SettingsPageLayout>
+
       <SettingsPageLayout icon={<SquaresIcon></SquaresIcon>} id="interface">
         <>
           <Typography variant="main-title">Interface</Typography>

--- a/src/components/settings/pages/GeneralSettings.tsx
+++ b/src/components/settings/pages/GeneralSettings.tsx
@@ -113,6 +113,14 @@ export function GeneralSettings() {
     sendRPCPacket(RpcMessage.ChangeSettingsRequest, settings);
 
     setConfig({ debug: values.interface.devmode });
+
+    // if devmode was changed update the page
+    const skeletonSettings = document.getElementById('skeletonSettings');
+    if (skeletonSettings !== null) {
+      skeletonSettings.style.display = values.interface.devmode
+        ? 'block'
+        : 'none';
+    }
   };
 
   useEffect(() => {
@@ -275,7 +283,7 @@ export function GeneralSettings() {
               movment patterns.
             </Typography>
           </div>
-          <div className="grid grid-cols-2 gap-3 pt-3 ">
+          <div className="grid grid-cols-2 gap-3 pb-5">
             <CheckBox
               variant="toggle"
               outlined
@@ -290,6 +298,54 @@ export function GeneralSettings() {
               name="toggles.skatingCorrection"
               label="Skating correction"
             />
+          </div>
+
+          <Typography bold>Arm-FK</Typography>
+          <div className="flex flex-col pt-2 pb-4">
+            <Typography color="secondary">
+              Settings for how the arm kinematics behave.
+            </Typography>
+          </div>
+          <div className="grid grid-cols-1 pb-5">
+            <CheckBox
+              variant="toggle"
+              outlined
+              control={control}
+              name="toggles.forceArmsFromHmd"
+              label="Force arms from HMD"
+            />
+          </div>
+          <div id="skeletonSettings">
+            <Typography bold>Skeleton settings</Typography>
+            <div className="flex flex-col pt-2 pb-4">
+              <Typography color="secondary">
+                More settings that allow further tweaking of the fk settings. It
+                it is recomended to leave these at the default.
+              </Typography>
+            </div>
+            <div className="grid grid-cols-3 gap-3 pb-5">
+              <CheckBox
+                variant="toggle"
+                outlined
+                control={control}
+                name="toggles.extendedSpine"
+                label="Extended Spine"
+              />
+              <CheckBox
+                variant="toggle"
+                outlined
+                control={control}
+                name="toggles.extendedPelvis"
+                label="Extended Pelvis"
+              />
+              <CheckBox
+                variant="toggle"
+                outlined
+                control={control}
+                name="toggles.extendedKnee"
+                label="Extended Knee"
+              />
+            </div>
           </div>
         </>
       </SettingsPageLayout>

--- a/src/components/settings/pages/GeneralSettings.tsx
+++ b/src/components/settings/pages/GeneralSettings.tsx
@@ -5,9 +5,7 @@ import {
   ChangeSettingsRequestT,
   FilteringSettingsT,
   FilteringType,
-  ModelSettings,
   ModelSettingsT,
-  ModelToggles,
   ModelTogglesT,
   RpcMessage,
   SettingsRequestT,
@@ -39,6 +37,10 @@ interface SettingsForm {
     ticks: number;
   };
   toggles: {
+    extendedSpine: boolean;
+    extendedPelvis: boolean;
+    extendedKnee: boolean;
+    forceArmsFromHmd: boolean;
     floorClip: boolean;
     skatingCorrection: boolean;
   };
@@ -64,7 +66,11 @@ export function GeneralSettings() {
           legs: false,
         },
         toggles: {
-          floorClip: false,
+          extendedSpine: true,
+          extendedPelvis: true,
+          extendedKnee: true,
+          forceArmsFromHmd: false,
+          floorClip: true,
           skatingCorrection: false,
         },
         filtering: { intensity: 0, ticks: 0 },
@@ -89,8 +95,12 @@ export function GeneralSettings() {
     const toggles = new ModelTogglesT();
     toggles.floorClip = values.toggles.floorClip;
     toggles.skatingCorrection = values.toggles.skatingCorrection;
-    modelSettings.toggles = toggles;
+    toggles.extendedKnee = values.toggles.extendedKnee;
+    toggles.extendedPelvis = values.toggles.extendedPelvis;
+    toggles.extendedSpine = values.toggles.extendedSpine;
+    toggles.forceArmsFromHmd = values.toggles.forceArmsFromHmd;
 
+    modelSettings.toggles = toggles;
     settings.modelSettings = modelSettings;
 
     const filtering = new FilteringSettingsT();
@@ -117,6 +127,9 @@ export function GeneralSettings() {
     reset({
       ...(settings.steamVrTrackers
         ? { trackers: settings.steamVrTrackers }
+        : {}),
+      ...(settings.modelSettings.toggles
+        ? { toggles: settings.modelSettings.toggles }
         : {}),
       ...(settings.filtering ? { filtering: settings.filtering } : {}),
       interface: {

--- a/src/components/settings/pages/GeneralSettings.tsx
+++ b/src/components/settings/pages/GeneralSettings.tsx
@@ -6,7 +6,9 @@ import {
   FilteringSettingsT,
   FilteringType,
   ModelSettings,
+  ModelSettingsT,
   ModelToggles,
+  ModelTogglesT,
   RpcMessage,
   SettingsRequestT,
   SettingsResponseT,
@@ -83,11 +85,13 @@ export function GeneralSettings() {
       settings.steamVrTrackers = trackers;
     }
 
-    const toggles = new ModelToggles();
+    const modelSettings = new ModelSettingsT();
+    const toggles = new ModelTogglesT();
     toggles.floorClip = values.toggles.floorClip;
     toggles.skatingCorrection = values.toggles.skatingCorrection;
+    modelSettings.toggles = toggles;
 
-    settings.modelSettings = toggles;
+    settings.modelSettings = modelSettings;
 
     const filtering = new FilteringSettingsT();
     filtering.type = values.filtering.type;

--- a/src/components/settings/pages/GeneralSettings.tsx
+++ b/src/components/settings/pages/GeneralSettings.tsx
@@ -5,6 +5,8 @@ import {
   ChangeSettingsRequestT,
   FilteringSettingsT,
   FilteringType,
+  ModelSettings,
+  ModelToggles,
   RpcMessage,
   SettingsRequestT,
   SettingsResponseT,
@@ -34,6 +36,10 @@ interface SettingsForm {
     intensity: number;
     ticks: number;
   };
+  toggles: {
+    floorClip: boolean;
+    skatingCorrection: boolean;
+  };
   interface: {
     devmode: boolean;
   };
@@ -55,6 +61,10 @@ export function GeneralSettings() {
           knees: false,
           legs: false,
         },
+        toggles: {
+          floorClip: false,
+          skatingCorrection: false,
+        },
         filtering: { intensity: 0, ticks: 0 },
         interface: { devmode: false },
       },
@@ -72,6 +82,12 @@ export function GeneralSettings() {
       trackers.elbows = values.trackers.elbows;
       settings.steamVrTrackers = trackers;
     }
+
+    const toggles = new ModelToggles();
+    toggles.floorClip = values.toggles.floorClip;
+    toggles.skatingCorrection = values.toggles.skatingCorrection;
+
+    settings.modelSettings = toggles;
 
     const filtering = new FilteringSettingsT();
     filtering.type = values.filtering.type;
@@ -226,6 +242,33 @@ export function GeneralSettings() {
               max={50}
               step={1}
             />
+          </div>
+          <div className="flex flex-col pt-2 pb-4">
+            <div className="flex flex-col pt-2 pb-4">
+              <Typography bold>Secondary Filtering</Typography>
+              <Typography color="secondary">
+                Floor clip can Reduces or even eliminates clipping with the but
+                but may cause problems when on your knees. Skating correction
+                corrects for ice skating, but can decrease accuracy in certain
+                movment patterns.
+              </Typography>
+            </div>
+            <div className="grid grid-cols-2 gap-3 pt-3 ">
+              <CheckBox
+                variant="toggle"
+                outlined
+                control={control}
+                name="toggles.floorClip"
+                label="Floor clip"
+              />
+              <CheckBox
+                variant="toggle"
+                outlined
+                control={control}
+                name="toggles.skatingCorrection"
+                label="Skating correction"
+              />
+            </div>
           </div>
         </>
       </SettingsPageLayout>


### PR DESCRIPTION
This PR goes along with the other Legtweaks PRs but also adds settings for the other available toggles to the settings of the new GUI. More specifically it adds a section to the settings called FK settings with floor clip, skating-correction, and force arms from HMD being the options shown at all times and the remaining toggles being hidden unless dev-mod is on.